### PR TITLE
reject the promise if stop() throws

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,11 +121,15 @@ class SynchronousWorker extends EventEmitter {
   }
 
   async stop(): Promise<void> {
-    return this[kStoppedPromise] ??= new Promise(resolve => {
+    return this[kStoppedPromise] ??= new Promise((resolve, reject) => {
       this[kHandle].signalStop();
       setImmediate(() => {
-        this[kHandle].stop();
-        resolve();
+        try {
+          this[kHandle].stop();
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
       });
     });
   }


### PR DESCRIPTION
I have situation where calling stop() would cause an `'illegal operation'` error being thrown by FreeEnvironment (I arrived there through some printfs).

Funnily enough, I can only reproduce this on top of Fastify+tap. I've tried reasoning on why could be causing this but I was not able to recreate the same "perfect storm". If you'd like, y7ou can take a look at this branch: https://github.com/mcollina/fastify-isolate/tree/broken-isolate.

Let me know if you have some way in which I could find out how to write a unit test for this.