### PR TITLE
Use C++11 ABI on Node.js 18.x+ on Linux

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [15.x, 16.x, 17.x]
+        node-version: [15.x, 16.x, 17.x, 18.x]
+        exclude:
+          - os: windows-latest
+            node-version: 15.x
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "mocha": "^8.1.3",
     "node-fetch": "^2.6.1",
     "nyc": "^15.1.0",
-    "ts-node": "^9.0.0",
+    "ts-node": "^10.8.1",
     "typescript": "^4.0.3"
   },
   "dependencies": {

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -1,6 +1,8 @@
+#include "node_version.h"
+
 // Node.js published binary compatibility
 #undef _GLIBCXX_USE_CXX11_ABI
-#ifdef __arm__
+#if defined(__arm__) || NODE_VERSION_AT_LEAST(18, 0, 0)
 #define _GLIBCXX_USE_CXX11_ABI 1
 #else
 #define _GLIBCXX_USE_CXX11_ABI 0


### PR DESCRIPTION
Fixes: https://github.com/addaleax/synchronous-worker/issues/6
Refs: https://github.com/nodejs/node/pull/36634