### PR TITLE
use fs.readFile instead of setImmediate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import bindings from 'bindings';
 import { EventEmitter } from 'events';
 import type Module from 'module';
+import fs from 'fs';
 const {
   SynchronousWorkerImpl,
   UV_RUN_DEFAULT,
@@ -123,7 +124,7 @@ class SynchronousWorker extends EventEmitter {
   async stop(): Promise<void> {
     return this[kStoppedPromise] ??= new Promise(resolve => {
       this[kHandle].signalStop();
-      setImmediate(() => {
+      fs.readFile(__filename, () => {
         this[kHandle].stop();
         resolve();
       });

--- a/test/index.ts
+++ b/test/index.ts
@@ -194,4 +194,18 @@ describe('SynchronousWorker allows running Node.js code', () => {
     });
     await w.stop();
   });
+
+  it('properly handles immediates when FreeEnvironment() is called on a shared event loop', async() => {
+    const w = new SynchronousWorker({
+      sharedEventLoop: true,
+      sharedMicrotaskQueue: true
+    });
+
+    setImmediate(() => {
+      setImmediate(() => {
+        setImmediate(() => {});
+      });
+    });
+    await w.stop();
+  });
 });


### PR DESCRIPTION
Signed-off-by: Matteo Collina <hello@matteocollina.com>

The solution to the immediate re-entrancy problem is to not use `setImmediate` to spin up the event loop. Using `fs` is a way to execute something in a different phase of the event loop, so we avoid the `setImmediate` re-entrancy issue.

Fixes #8 