### PR TITLE
Use custom setImmediate to avoid conflict with Node.js immediate loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint {src,test}/**/*.ts",
     "test": "npm run lint && npm run build && nyc npm run test-only",
     "test-nolint": "npm run build && npm run test-only",
-    "test-only": "mocha --colors -r ts-node/register test/*.ts",
+    "test-only": "mocha --trace-uncaught --colors -r ts-node/register test/*.ts",
     "build": "node-gyp rebuild && npm run compile-ts && gen-esm-wrapper . ./.esm-wrapper.mjs",
     "prepack": "npm run build",
     "compile-ts": "tsc -p tsconfig.json"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "lint": "eslint {src,test}/**/*.ts",
-    "test": "npm run lint && npm run build && nyc npm run test-only",
+    "test": "npm run lint && npm run build && npm run test-only",
     "test-nolint": "npm run build && npm run test-only",
     "test-only": "mocha --trace-uncaught --colors -r ts-node/register test/*.ts",
     "build": "node-gyp rebuild && npm run compile-ts && gen-esm-wrapper . ./.esm-wrapper.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,8 @@ const {
   SynchronousWorkerImpl,
   UV_RUN_DEFAULT,
   UV_RUN_ONCE,
-  UV_RUN_NOWAIT
+  UV_RUN_NOWAIT,
+  standaloneSetImmediate
 } = bindings('synchronous_worker');
 const kHandle = Symbol('kHandle');
 const kProcess = Symbol('kProcess');
@@ -123,7 +124,7 @@ class SynchronousWorker extends EventEmitter {
   async stop(): Promise<void> {
     return this[kStoppedPromise] ??= new Promise(resolve => {
       this[kHandle].signalStop();
-      setImmediate(() => {
+      standaloneSetImmediate(() => {
         this[kHandle].stop();
         resolve();
       });

--- a/test/index.ts
+++ b/test/index.ts
@@ -194,4 +194,18 @@ describe('SynchronousWorker allows running Node.js code', () => {
     });
     await w.stop();
   });
+
+  it('properly handles immediates when FreeEnvironment() is called on a shared event loop', async() => {
+    const w = new SynchronousWorker({
+      sharedEventLoop: true,
+      sharedMicrotaskQueue: true
+    });
+
+    setImmediate(() => {
+      setImmediate(() => {
+        setImmediate(() => {});
+      });
+    });
+    await w.stop();
+  });
 });


### PR DESCRIPTION
Co-authored-by: Matteo Collina <hello@matteocollina.com>
Fixes: https://github.com/addaleax/synchronous-worker/issues/8
Fixes: https://github.com/addaleax/synchronous-worker/pull/9